### PR TITLE
fix: make calendar show above toggle buttons

### DIFF
--- a/src/app/layout/views/AppLanding.jsx
+++ b/src/app/layout/views/AppLanding.jsx
@@ -13,7 +13,6 @@ import {
 
 import { SingleDatePicker } from 'react-dates';
 import 'react-dates/initialize';
-import 'react-dates/lib/css/_datepicker.css';
 
 import moment from 'moment';
 
@@ -152,6 +151,8 @@ export default function AppLanding({ cbSetUser }) {
                 onFocusChange={({ focused }) => setFocused(focused)} // PropTypes.func.isRequired
                 id="your_unique_id" // PropTypes.string.isRequired //why is this required and what should it be?
                 isOutsideRange={() => false}
+                numberOfMonths={1}
+                withPortal={true} // eslint-disable-line
               />
               <Button onClick={nextDay}>Next</Button>
             </ButtonGroup>

--- a/src/index.css
+++ b/src/index.css
@@ -33,3 +33,7 @@ div.list {
   min-height: 100%;
   height: 100%;
 }
+
+.SingleDatePicker_picker {
+  z-index: 10;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,12 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import './index.css';
 
 import reportWebVitals from './reportWebVitals';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
+import 'react-dates/lib/css/_datepicker.css';
+import './index.css';
 
 import App from './app/layout/App';
 import './app/config/fire';


### PR DESCRIPTION
Addresses the bug detailed in issue #51 
- where toggle buttons appear on top of the calendar in the z-axis
- the calendar is not usable on a mobile display